### PR TITLE
Better debugging

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,13 +1,18 @@
 'use strict';
 
 const stew = require('broccoli-stew');
+const BroccoliDebug = require('broccoli-debug');
 const themeName = process.env.EMBER_THEME || 'default';
+
+const debugTree = BroccoliDebug.buildDebugCallback('select-sass-theme');
 
 module.exports = {
   name: require('./package').name,
 
   preprocessTree(type, tree) {
     if (type === 'css' && themeName !== 'default') {
+      tree = debugTree(tree, 'input');
+
       tree = stew.rm(tree, `app/styles/config/themes/_current-theme.scss`);
 
       tree = stew.mv(
@@ -27,7 +32,7 @@ module.exports = {
         `${this.app.name}/styles/config/themes/_current-theme.scss`
       );
 
-      return stew.debug(tree);
+      tree = debugTree(tree, 'output');
     }
 
     return tree;

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "test:ember-compatibility": "ember try:each"
   },
   "dependencies": {
+    "broccoli-debug": "^0.6.5",
     "broccoli-stew": "^3.0.0",
     "ember-cli-babel": "^7.26.6"
   },
@@ -67,7 +68,6 @@
     "edition": "octane"
   },
   "ember-addon": {
-    "configPath": "tests/dummy/config",
-    "before": "ember-cli-sass"
+    "configPath": "tests/dummy/config"
   }
 }


### PR DESCRIPTION
[broccoli-debug](https://github.com/broccolijs/broccoli-debug) is the better solution for brcolli tree debugging, as it allows to keep the debug code in a "production version", while only emmiting debug output when needed. Here: add e.g. `BROCCOLI_DEBUG=select-sass-theme:*`